### PR TITLE
Webapp ify script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.vscode

--- a/convert.js
+++ b/convert.js
@@ -1,8 +1,8 @@
 // Small node conversion app to convert CSV open data stocktakes and convert to data.json harvestable endpoints
 
 //use the csvtojson parser as it is nice and fast https://www.npmjs.com/package/csvtojson
-const csv = require('csvtojson')
 const fs = require('fs');
+const converter = require('./convert_logic');
 
 //get arguments and flags set
 // --file path to csv file
@@ -33,72 +33,13 @@ if(process.argv.indexOf("--output") != -1){ //does our flag exist?
 }
 
 
-const converter = csv({
-  ignoreEmpty: true,
-  colParser: {
-    'keywords': function (item, head, resultRow, row, colIdx){
-       resultRow['keyword']=item.toLowerCase().replace(/(~|`|!|@|#|$|%|^|&|\*|\(|\)|{|}|\[|\]|;|:|\"|'|<|\.|>|\?|\/|\\|\||-|_|\+|=)/g,"").split(/\s*[,]\s*/);
-    },
-    'updateFrequency': function (item, head, resultRow, row , colIdx){
-      //See https://project-open-data.cio.gov/iso8601_guidance#accrualperiodicity
-      switch (item) {
-        case 'Annual':
-        case 'Annually':
-            resultRow['accrualPeriodicity']='R/P1Y'
-          break;
-        case '6-Monthly':
-            resultRow['accrualPeriodicity']='R/P6M'
-          break;
-        case 'Quarterly':
-            resultRow['accrualPeriodicity']='R/P3M'
-          break;
-        case 'Monthly':
-            resultRow['accrualPeriodicity']='R/P1M'
-          break;
-        case 'Weekly':
-            resultRow['accrualPeriodicity']='R/P1W'
-          break;
-        case 'Daily':
-            resultRow['accrualPeriodicity']='R/P1D'
-          break;
-        default:
-            resultRow['accrualPeriodicity']='irregular'
-      }
-    },
-    'issued': function (item, head, resultRow, row, colIdx){
-         return item.split("/").reverse().join("-");
-    },
-    'modified': function (item, head, resultRow, row, colIdx){
-         return item.split("/").reverse().join("-");
-    },
-    'licence': function (item, head, resultRow, row, colIdx){
-         resultRow['license']=item
-    }
-  }
-})
-.fromFile(file, function(err,result){
-    // if an error has occured then handle it
-    if(err){
-        console.log("An Error Has Occured");
-        console.log(err);
-    }
-    // create a variable called json and store
-    // the result of the conversion
-    var dataset = JSON.stringify(result,null,4);
-    var catalog =
-`{
-  "@context": "https://www.data.govt.nz/catalog.jsonld",
-	"@id": "${url}/data.json",
-	"@type": "dcat:Catalog",
-	"conformsTo": "https://www.data.govt.nz/toolkit/schema",
-  "dataset":`;
-
-    fs.writeFile(output + "data.json", catalog + dataset + '}', 'utf8', function (err) {
+const inputCSV = fs.readFileSync(file, 'utf8');
+converter.convert(inputCSV, url)
+  .then(data => {
+    fs.writeFile(output + "data.json", data, 'utf8', function (err) {
       if (err) {
           return console.log(err);
       }
       console.log("data.json generated.");
-
     });
-
-});
+  });

--- a/convert_logic.js
+++ b/convert_logic.js
@@ -1,0 +1,76 @@
+const csv = require('csvtojson')
+const fs = require('fs');
+
+module.exports = {}
+
+/**
+ * Take the csv content and convert it to a 
+ * @return Promise<string> dcatJson content
+ */
+module.exports.convert = (csvContent, sourceURL) => {
+
+  return new Promise((resolve, reject) => {
+    const converter = csv({
+      ignoreEmpty: true,
+      colParser: {
+        'keywords': function (item, head, resultRow, row, colIdx){
+          resultRow['keyword']=item.toLowerCase().replace(/(~|`|!|@|#|$|%|^|&|\*|\(|\)|{|}|\[|\]|;|:|\"|'|<|\.|>|\?|\/|\\|\||-|_|\+|=)/g,"").split(/\s*[,]\s*/);
+        },
+        'updateFrequency': function (item, head, resultRow, row , colIdx){
+          //See https://project-open-data.cio.gov/iso8601_guidance#accrualperiodicity
+          switch (item) {
+            case 'Annual':
+            case 'Annually':
+                resultRow['accrualPeriodicity']='R/P1Y'
+              break;
+            case '6-Monthly':
+                resultRow['accrualPeriodicity']='R/P6M'
+              break;
+            case 'Quarterly':
+                resultRow['accrualPeriodicity']='R/P3M'
+              break;
+            case 'Monthly':
+                resultRow['accrualPeriodicity']='R/P1M'
+              break;
+            case 'Weekly':
+                resultRow['accrualPeriodicity']='R/P1W'
+              break;
+            case 'Daily':
+                resultRow['accrualPeriodicity']='R/P1D'
+              break;
+            default:
+                resultRow['accrualPeriodicity']='irregular'
+          }
+        },
+        'issued': function (item, head, resultRow, row, colIdx){
+            return item.split("/").reverse().join("-");
+        },
+        'modified': function (item, head, resultRow, row, colIdx){
+            return item.split("/").reverse().join("-");
+        },
+        'licence': function (item, head, resultRow, row, colIdx){
+            resultRow['license']=item
+        }
+      }
+    })
+    .fromString(csvContent, (err, result) => {
+        // if an error has occured then handle it
+        if(err){
+          console.error('Fatal error from csv parse lib', err);
+          return reject(err)
+        }
+        // create a variable called json and store
+        // the result of the conversion
+        var dataset = JSON.stringify(result,null,4);
+        var catalog =
+    `{
+      "@context": "https://www.data.govt.nz/catalog.jsonld",
+      "@id": "${sourceURL}/data.json",
+      "@type": "dcat:Catalog",
+      "conformsTo": "https://www.data.govt.nz/toolkit/schema",
+      "dataset":`;
+        const allContent = catalog + dataset + '}';
+        resolve(allContent);
+    });
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,16 +2,32 @@
   "name": "data-govt-nz_schema-tools",
   "version": "0.1.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "accepts": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
-      "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8="
+      "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
+      "requires": {
+        "mime-types": "2.1.17",
+        "negotiator": "0.6.1"
+      }
     },
     "ajv": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
-      "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk="
+      "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.0.0",
+        "json-schema-traverse": "0.3.1",
+        "json-stable-stringify": "1.0.1"
+      }
+    },
+    "append-field": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-0.1.0.tgz",
+      "integrity": "sha1-bdxY+gg8e8VF08WZWygwzCNm1Eo="
     },
     "array-flatten": {
       "version": "1.1.1",
@@ -47,17 +63,44 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
     },
     "body-parser": {
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ="
+      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+      "requires": {
+        "bytes": "3.0.0",
+        "content-type": "1.0.4",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "on-finished": "2.3.0",
+        "qs": "6.5.1",
+        "raw-body": "2.3.2",
+        "type-is": "1.6.15"
+      }
     },
     "boom": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE="
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "requires": {
+        "hoek": "4.2.0"
+      }
+    },
+    "busboy": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
+      "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
+      "requires": {
+        "dicer": "0.2.5",
+        "readable-stream": "1.1.14"
+      }
     },
     "bytes": {
       "version": "3.0.0",
@@ -77,7 +120,49 @@
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "concat-stream": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
     },
     "content-disposition": {
       "version": "0.5.2",
@@ -108,28 +193,44 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "requires": {
+        "boom": "5.2.0"
+      },
       "dependencies": {
         "boom": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw=="
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "requires": {
+            "hoek": "4.2.0"
+          }
         }
       }
     },
     "csvtojson": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/csvtojson/-/csvtojson-1.1.7.tgz",
-      "integrity": "sha1-F97QeuwNjAHy1vaHHPo2q4ixSbE="
+      "integrity": "sha1-F97QeuwNjAHy1vaHHPo2q4ixSbE=",
+      "requires": {
+        "lodash": "4.17.4",
+        "strip-bom": "1.0.0"
+      }
     },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA="
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
     },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -137,20 +238,32 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
+    "dicer": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
+      "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
+      "requires": {
+        "readable-stream": "1.1.14",
+        "streamsearch": "0.1.2"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -158,9 +271,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "encodeurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -175,7 +288,47 @@
     "express": {
       "version": "4.16.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
-      "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w="
+      "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
+      "requires": {
+        "accepts": "1.3.4",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
+        "content-disposition": "0.5.2",
+        "content-type": "1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "finalhandler": "1.1.0",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "2.0.2",
+        "qs": "6.5.1",
+        "range-parser": "1.2.0",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.1",
+        "serve-static": "1.13.1",
+        "setprototypeof": "1.1.0",
+        "statuses": "1.3.1",
+        "type-is": "1.6.15",
+        "utils-merge": "1.0.1",
+        "vary": "1.1.2"
+      }
+    },
+    "express.js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/express.js/-/express.js-1.0.0.tgz",
+      "integrity": "sha1-41ueXrBNEsRGp+/eCbqnhcKVJCQ=",
+      "requires": {
+        "express": "4.16.2"
+      }
     },
     "extend": {
       "version": "3.0.1",
@@ -195,7 +348,16 @@
     "finalhandler": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
-      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U="
+      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
+      }
     },
     "first-chunk-stream": {
       "version": "1.0.0",
@@ -210,7 +372,12 @@
     "form-data": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8="
+      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.17"
+      }
     },
     "forwarded": {
       "version": "0.1.2",
@@ -225,7 +392,10 @@
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo="
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -235,12 +405,22 @@
     "har-validator": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0="
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "requires": {
+        "ajv": "5.2.2",
+        "har-schema": "2.0.0"
+      }
     },
     "hawk": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ=="
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "requires": {
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.0",
+        "sntp": "2.0.2"
+      }
     },
     "heredoc": {
       "version": "1.3.1",
@@ -256,7 +436,18 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
       "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+      "requires": {
+        "depd": "1.1.1",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.3",
+        "statuses": "1.3.1"
+      },
       "dependencies": {
+        "depd": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+        },
         "setprototypeof": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
@@ -267,7 +458,12 @@
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE="
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
+      }
     },
     "iconv-lite": {
       "version": "0.4.19",
@@ -294,6 +490,11 @@
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -318,7 +519,10 @@
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8="
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "0.0.0"
+      }
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -333,7 +537,13 @@
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI="
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
     },
     "lodash": {
       "version": "4.17.4",
@@ -368,12 +578,43 @@
     "mime-types": {
       "version": "2.1.17",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo="
+      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "requires": {
+        "mime-db": "1.30.0"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
     },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "multer": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.3.0.tgz",
+      "integrity": "sha1-CSsmcPaEb6SRSWXvyM+Uwg/sbNI=",
+      "requires": {
+        "append-field": "0.1.0",
+        "busboy": "0.2.14",
+        "concat-stream": "1.6.0",
+        "mkdirp": "0.5.1",
+        "object-assign": "3.0.0",
+        "on-finished": "2.3.0",
+        "type-is": "1.6.15",
+        "xtend": "4.0.1"
+      }
     },
     "negotiator": {
       "version": "0.6.1",
@@ -383,17 +624,28 @@
     "node-json-transform": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/node-json-transform/-/node-json-transform-1.0.13.tgz",
-      "integrity": "sha1-KbH5Oaea1g2bSLIJZ9VgShHexeI="
+      "integrity": "sha1-KbH5Oaea1g2bSLIJZ9VgShHexeI=",
+      "requires": {
+        "lodash": "4.17.4"
+      }
     },
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
     },
+    "object-assign": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+      "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc="
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
     },
     "parseurl": {
       "version": "1.3.2",
@@ -410,10 +662,19 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
     "proxy-addr": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
-      "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew="
+      "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
+      "requires": {
+        "forwarded": "0.1.2",
+        "ipaddr.js": "1.5.2"
+      }
     },
     "punycode": {
       "version": "1.4.1",
@@ -433,12 +694,53 @@
     "raw-body": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k="
+      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+      "requires": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "unpipe": "1.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "0.0.1",
+        "string_decoder": "0.10.31"
+      }
     },
     "request": {
       "version": "2.82.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.82.0.tgz",
-      "integrity": "sha512-/QWqfmyTfQ4OYs6EhB1h2wQsX9ZxbuNePCvCm0Mdz/mxw73mjdg0D4QdIl0TQBFs35CZmMXLjk0iCGK395CUDg=="
+      "integrity": "sha512-/QWqfmyTfQ4OYs6EhB1h2wQsX9ZxbuNePCvCm0Mdz/mxw73mjdg0D4QdIl0TQBFs35CZmMXLjk0iCGK395CUDg==",
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.1",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.17",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.2",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.1.0"
+      }
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -448,12 +750,33 @@
     "send": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
-      "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A=="
+      "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "1.6.2",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.3.1"
+      }
     },
     "serve-static": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
-      "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ=="
+      "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
+      "requires": {
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
+        "send": "0.16.1"
+      }
     },
     "setprototypeof": {
       "version": "1.1.0",
@@ -463,17 +786,40 @@
     "sntp": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
-      "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys="
+      "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
+      "requires": {
+        "hoek": "4.2.0"
+      }
     },
     "sshpk": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M="
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      }
     },
     "statuses": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+    },
+    "streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
       "version": "0.0.5",
@@ -483,17 +829,27 @@
     "strip-bom": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-      "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q="
+      "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
+      "requires": {
+        "first-chunk-stream": "1.0.0",
+        "is-utf8": "0.2.1"
+      }
     },
     "tough-cookie": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
+      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+      "requires": {
+        "punycode": "1.4.1"
+      }
     },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -504,12 +860,26 @@
     "type-is": {
       "version": "1.6.15",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA="
+      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "2.1.17"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -529,7 +899,17 @@
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA="
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      }
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {},
   "scripts": {
+    "start": "node web.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,12 @@
   "description": "The data.json metadata schema used to harvest datasets from agencies on data.govt.nz",
   "main": "convert.js",
   "dependencies": {
+    "body-parser": "^1.18.2",
     "csvtojson": "^1.1.7",
     "express": "^4.16.2",
+    "express.js": "^1.0.0",
     "heredoc": "^1.3.1",
+    "multer": "^1.3.0",
     "node-json-transform": "^1.0.13",
     "request": "^2.82.0"
   },

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,51 @@
+<html>
+  <head>
+    <title>Schema is a tool for creating dcat json from a csv</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/semantic-ui@2.2.10/dist/semantic.min.css">
+    <link rel="stylesheet" href="/static/style.css">
+    <script src="/static/app.js"></script>
+  </head>
+  <body>
+
+    <div class="ui text container">
+      <div class="ui segment">
+      <h1 class='ui dividing header'>Data.govt.nz Dcat Generator</h1>
+      <a href='https://github.com/data-govt-nz/schema' rel='nofollow'>
+        Clone me on github ond run me anywhere
+      </a>
+      <p>
+          Part of moving to the CKAN data portal is improving our adaoption of international standards that aid in interoperability. One of these is the data.json standard that was put together as part of the US Project Open Data initiaive and has since been adopted by many other countries as a consistent way to express stocktakes of open data at an agency level.
+      </p>
+      <p>The idea here is to replace the current and dated ATOM/RSS feed standard which is no longer fit for purpose.</p>
+      <p>The data.json schema:</p>
+      <ul>
+        <li>is able to represent individual file level resources for example you might have a csv, kml, shp file of the same data set.</li>
+        <li>is an international standard used by many other government data portals.</li>
+        <li>allows for easy automation of harvesting into the the new CKAN data portal.</li>
+      </ul>
+      </div>
+    </div>
+
+    <div class="ui text container csv-upload-form">
+      <div class="ui segment">
+        <h1 class='ui dividing header'>Convert your csv to DCAT</h1>
+        <p>Upload a csv and the url where you will be hosting the created json file</p>
+        <p><a href="/example.csv">Download the example csv content here</a></p>
+        <form class='ui form' method="post" action="/submit" enctype="multipart/form-data">
+          <div class="field">
+            <label>Source URL
+            <input required type="text" name='source_url' placeholder='<yoursite>/data.json'/>
+            </label>
+          </div>
+          <div class="field">
+            <label>
+              Source CSV
+              <input required type="file" name="csv_file" id="">
+            </label>
+          </div>
+          <button class='ui button primary' type="submit">Create a dcat API endpoint</button>
+        </form>
+      </div>
+    </div>
+  </body>
+</html>

--- a/static/index.html
+++ b/static/index.html
@@ -6,43 +6,25 @@
   </head>
   <body>
 
-    <div class="ui text container">
-      <div class="ui segment">
-      <h1 class='ui dividing header'>Data.govt.nz Dcat Generator</h1>
-      <a href='https://github.com/data-govt-nz/schema' rel='nofollow'>
-        Clone me on github ond run me anywhere
-      </a>
-      <p>
-          Part of moving to the CKAN data portal is improving our adaoption of international standards that aid in interoperability. One of these is the data.json standard that was put together as part of the US Project Open Data initiaive and has since been adopted by many other countries as a consistent way to express stocktakes of open data at an agency level.
-      </p>
-      <p>The idea here is to replace the current and dated ATOM/RSS feed standard which is no longer fit for purpose.</p>
-      <p>The data.json schema:</p>
-      <ul>
-        <li>is able to represent individual file level resources for example you might have a csv, kml, shp file of the same data set.</li>
-        <li>is an international standard used by many other government data portals.</li>
-        <li>allows for easy automation of harvesting into the the new CKAN data portal.</li>
-      </ul>
-      </div>
-    </div>
-
     <div class="ui text container csv-upload-form">
       <div class="ui segment">
-        <h1 class='ui dividing header'>Convert your csv to DCAT</h1>
-        <p>Upload a csv and the url where you will be hosting the created json file</p>
-        <p><a href="/example.csv">Download the example csv content here</a></p>
+        <h1 class='ui dividing header'>Convert CSV to DCAT json</h1>
+        <ol class="ui list">
+          <li>Find the data sources in your organization</li>
+          <li>Download the <a href="/example.csv">example CSV</a> and update it with your information</li>
+          <li>Upload your csv and convert it into a data.json dataset file</li>
+        </ol>
+        </p>
         <form class='ui form' method="post" action="/submit" enctype="multipart/form-data">
           <div class="field">
-            <label>Source URL
+            <div class="ui pointing below basic red label">Enter the base url of your data.json host</div>
             <input required type="text" name='source_url' placeholder='<yoursite>/data.json'/>
-            </label>
           </div>
           <div class="field">
-            <label>
-              Source CSV
               <input required type="file" name="csv_file" id="">
-            </label>
+              <div class="ui pointing basic red label">Upload the csv with your dataset information</div>
           </div>
-          <button class='ui button primary' type="submit">Create a dcat API endpoint</button>
+          <button class='ui button green' type="submit">Download your data.json</button>
         </form>
       </div>
     </div>

--- a/static/index.html
+++ b/static/index.html
@@ -3,7 +3,6 @@
     <title>Schema is a tool for creating dcat json from a csv</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/semantic-ui@2.2.10/dist/semantic.min.css">
     <link rel="stylesheet" href="/static/style.css">
-    <script src="/static/app.js"></script>
   </head>
   <body>
 

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,6 @@
+body {
+  padding-top: 34px;
+}
+.csv-upload-form {
+  padding-top: 34px;
+}

--- a/web.js
+++ b/web.js
@@ -67,6 +67,8 @@ app.get('/api/:id/data.json', (req, res) => {
     return
   }
   res.header('Content-Type', 'application/json')
+  res.header(`Content-Disposition`, `attachment; filename="data.json"`)
+  res.header('Content-Transfer-Encoding', 'binary')
   res.status(200);
   res.send(GLOBAL_DATA[req.params.id].dcat)
 })

--- a/web.js
+++ b/web.js
@@ -1,0 +1,88 @@
+const express = require('express')
+const fs = require('fs')
+const app = express()
+const multer = require('multer')
+const bodyParser = require('body-parser');
+const csvToDcat = require('./convert_logic');
+
+const upload = multer({storage: multer.memoryStorage()})
+
+/**
+ * Global state of the service, lists all the dcats in memory
+ */
+const GLOBAL_DATA = {};
+
+app.use(bodyParser.urlencoded({extended: true}));
+
+app.get('/', (req, res) => {
+  fs.readFile('./static/index.html', (err, data) => {
+    if (err !== null) {
+      res.status(500).send(err)
+    } else {
+      res.header().set('Content-Type', 'text/html')
+      res.send(data)
+    }
+  })
+})
+
+app.post('/submit', upload.single('csv_file'), (req, res) => {
+  console.log('got a request to create a dcat api endpoint', req.file, req.boy)
+
+  // TODO store and redirect
+  csvToDcat.convert(req.file.buffer.toString(), req.body['source_url'])
+    .then(dat => {
+      const newEndpointId = fakeID()
+      const newEndpoint = {
+        sourceUrl: req.body['source_url'],
+        dcat: dat
+      }
+      GLOBAL_DATA[newEndpointId] = newEndpoint;
+      const newUrl = `/api/${newEndpointId}/data.json`;
+      res.redirect(newUrl)
+      res.end()
+      console.log('created a new api endpoint at ', newUrl);
+    })
+    .catch(err => {
+      console.log('could not convert file', err)
+      res.status(500).send(err.toString())
+    })
+})
+
+app.get('/example.csv', (req, res) => {
+  console.log('got a request to download the example csv')
+  fs.readFile('./example.csv', (err, data) => {
+    if (err !== null) {
+      res.status(500).send(err)
+      return
+    }
+    res.header('Content-Type', 'text/csv')
+    res.send(data)
+  })
+})
+
+app.get('/api/:id/data.json', (req, res) => {
+  if (!req.params.id) {
+    console.error('You must have an id param defined')
+    res.status(500).send('you must specifiy an id parameter')
+    return
+  }
+  res.header('Content-Type', 'application/json')
+  res.status(200);
+  res.send(GLOBAL_DATA[req.params.id].dcat)
+})
+
+app.use('/static', express.static('static'))
+
+
+app.listen(3000, () => console.log('Example app listening on port 3000!'))
+
+/**
+ * A simple utillity function for generating an (fake) GUID-4
+ */
+function fakeID() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = Math.random()*16|0,
+          v = c == 'x' ? r : (r&0x3|0x8);
+      return v.toString(16);
+  });
+}


### PR DESCRIPTION
Had a few moments in the Petone library, and decided to mash together a little webapp implementation of the conversion script.

To test it out, simply pull the branch down, `npm install` then `npm start`. The webapp will be running 
 at http://localhost:3000 